### PR TITLE
Fixed bug with fulltext() call failing on some input

### DIFF
--- a/newspaper/api.py
+++ b/newspaper/api.py
@@ -88,6 +88,9 @@ def fulltext(html, language='en'):
     doc = document_cleaner.clean(doc)
 
     top_node = extractor.calculate_best_node(doc)
-    top_node = extractor.post_cleanup(top_node)
-    text, article_html = output_formatter.get_formatted(top_node)
+    if top_node is not None:
+        top_node = extractor.post_cleanup(top_node)
+        text, article_html = output_formatter.get_formatted(top_node)
+    else:
+        text = ''
     return text

--- a/newspaper/cleaners.py
+++ b/newspaper/cleaners.py
@@ -24,7 +24,7 @@ class DocumentCleaner(object):
             "|tags|socialnetworking|socialNetworking|cnnStryHghLght"
             "|cnn_stryspcvbx|^inset$|pagetools|post-attributes"
             "|welcome_form|contentTools2|the_answers"
-            "|communitypromo|runaroundLeft|subscribe|vcard|articleheadings"
+            "|communitypromo|runaroundLeft|subscribe(?!r-hider|-truncate)|vcard|articleheadings"
             "|date(?!line-storybody)|^print$|popup|author-dropdown|tools|socialtools|byline"
             "|konafilter|KonaFilter|breadcrumbs|^fn$|wp-caption-text"
             "|legende|ajoutVideo|timestamp|js_replies"
@@ -127,7 +127,7 @@ class DocumentCleaner(object):
         # class
         naughty_classes = self.parser.xpath_re(doc, self.nauthy_classes_re)
         for node in naughty_classes:
-            if not node.xpath(self.contains_article):
+            if not node.xpath(self.contains_article) and node.get('itemprop') != 'articleBody':
                 self.parser.remove(node)
         # name
         naughty_names = self.parser.xpath_re(doc, self.nauthy_names_re)

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -769,7 +769,6 @@ class ContentExtractor(object):
         return set(tags)
 
     def calculate_best_node(self, doc):
-        top_node = None
         nodes_to_check = self.nodes_to_check(doc)
         starting_boost = float(1.0)
         cnt = 0
@@ -828,17 +827,7 @@ class ContentExtractor(object):
             cnt += 1
             i += 1
 
-        top_node_score = 0
-        for e in parent_nodes:
-            score = self.get_score(e)
-
-            if score > top_node_score:
-                top_node = e
-                top_node_score = score
-
-            if top_node is None:
-                top_node = e
-        return top_node
+        return max(parent_nodes, key=self.get_score, default=None)
 
     def is_boostable(self, node):
         """A lot of times the first paragraph might be the caption under an image


### PR DESCRIPTION
Do not clean out nodes with 'subscriber-hider' and 'subscribe-truncate' classes
Do not clean out nodes with itemprop=articleBody
Simplified search for node with maximum score a bit